### PR TITLE
refactor: stateless message processors

### DIFF
--- a/src/main/java/bot/core/model/messageProcessing/CommandMessageProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/CommandMessageProcessor.java
@@ -8,19 +8,14 @@ import org.slf4j.LoggerFactory;
 
 public class CommandMessageProcessor implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(EditInfoProcessor.class);
-    private final SessionState state;
-
-    public CommandMessageProcessor(SessionState state) {
-        this.state = state;
-    }
 
     @Override
-    public boolean canProcess(MessageContext message) {
+    public boolean canProcess(MessageContext message, SessionState state) {
         return message.isCommand();
     }
 
     @Override
-    public void process(MessageContext message) {
+    public void process(MessageContext message, SessionState state) {
         CommandHandler handler = new CommandHandler(state, message.getChatId());
         handler.handle(message);
     }

--- a/src/main/java/bot/core/model/messageProcessing/EditHelpProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/EditHelpProcessor.java
@@ -9,19 +9,14 @@ import org.slf4j.LoggerFactory;
 
 public class EditHelpProcessor implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(EditInfoProcessor.class);
-    private final SessionState state;
-
-    public EditHelpProcessor(SessionState session) {
-        this.state = session;
-    }
 
     @Override
-    public boolean canProcess(MessageContext message) {
+    public boolean canProcess(MessageContext message, SessionState state) {
         return state.isEditingHelp() && message.isFromAdmin() && !message.getText().equals("/cancel");
     }
 
     @Override
-    public void process(MessageContext message) {
+    public void process(MessageContext message, SessionState state) {
         log.info("Editing help for chatId={}", message.getChatId());
         DataUtils.setInfo(message.getText());
         state.editHelp();

--- a/src/main/java/bot/core/model/messageProcessing/EditInfoProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/EditInfoProcessor.java
@@ -9,19 +9,14 @@ import org.slf4j.LoggerFactory;
 
 public class EditInfoProcessor implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(EditInfoProcessor.class);
-    private final SessionState state;
-
-    public EditInfoProcessor(SessionState session) {
-        this.state = session;
-    }
 
     @Override
-    public boolean canProcess(MessageContext message) {
+    public boolean canProcess(MessageContext message, SessionState state) {
         return state.isEditingInfo() && message.isFromAdmin() && !message.getText().equals("/cancel");
     }
 
     @Override
-    public void process(MessageContext message) {
+    public void process(MessageContext message, SessionState state) {
         log.info("Editing info for chatId={}", message.getChatId());
         DataUtils.setInfo(message.getText());
         state.editInfo();

--- a/src/main/java/bot/core/model/messageProcessing/GroupMessageProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/GroupMessageProcessor.java
@@ -15,14 +15,9 @@ import java.util.Map;
 
 public class GroupMessageProcessor implements MessageProcessor {
     Logger log = LoggerFactory.getLogger(GroupMessageProcessor.class);
-    SessionState state;
-
-    public GroupMessageProcessor(SessionState state) {
-        this.state = state;
-    }
 
     @Override
-    public boolean canProcess(MessageContext ctx) {
+    public boolean canProcess(MessageContext ctx, SessionState state) {
         if (state.pendingGroupName == null) return false;
 
         if (ctx.isFromGroup()) {
@@ -49,7 +44,7 @@ public class GroupMessageProcessor implements MessageProcessor {
 
 
     @Override
-    public void process(MessageContext ctx) {
+    public void process(MessageContext ctx, SessionState state) {
         long chatId = ctx.getChatId();
         log.info("Bot added to new group");
 

--- a/src/main/java/bot/core/model/messageProcessing/MessageProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/MessageProcessor.java
@@ -2,8 +2,9 @@ package bot.core.model.messageProcessing;
 
 
 import bot.core.model.MessageContext;
+import bot.core.control.SessionState;
 
 public interface MessageProcessor {
-    public boolean canProcess(MessageContext message);
-    public void process(MessageContext message);
+    boolean canProcess(MessageContext message, SessionState state);
+    void process(MessageContext message, SessionState state);
 }

--- a/src/main/java/bot/core/model/messageProcessing/SetGroupNameProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/SetGroupNameProcessor.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SetGroupNameProcessor implements MessageProcessor {
-    private final SessionState state;
     private static final Logger log = LoggerFactory.getLogger(SetGroupNameProcessor.class);
 
     public static final String GROUP_NAME_SETUP_INSTRUCTION = """
@@ -20,17 +19,14 @@ public class SetGroupNameProcessor implements MessageProcessor {
     Учтите, что название группы в Telegram останется без изменений — имя используется только во внутренней логике бота.
     """;
 
-    public SetGroupNameProcessor(SessionState state) {
-        this.state = state;
-    }
 
     @Override
-    public boolean canProcess(MessageContext ctx) {
+    public boolean canProcess(MessageContext ctx, SessionState state) {
         return state.isWaitingGroupName() && ctx.isFromAdmin() && !ctx.getText().equals("/cancel");
     }
 
     @Override
-    public void process(MessageContext ctx) {
+    public void process(MessageContext ctx, SessionState state) {
         String name = ctx.getText();
         long chatId = ctx.getChatId();
 


### PR DESCRIPTION
## Summary
- refactor `MessageProcessor` interface to pass `SessionState`
- update processor implementations to accept state in methods instead of constructors

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842cf752370832a8a723f514f86d917