### PR TITLE
Update processors to accept Session

### DIFF
--- a/src/main/java/bot/core/PaymentBot.java
+++ b/src/main/java/bot/core/PaymentBot.java
@@ -57,10 +57,10 @@ public class PaymentBot extends TelegramLongPollingBot {
 
         MessageContext ctx = new MessageContext(message);
 
-        if (historyForwardProcessor.canProcess(ctx, session.getState())) historyForwardProcessor.process(ctx, session.getState());
+        if (historyForwardProcessor.canProcess(ctx, session)) historyForwardProcessor.process(ctx, session);
         for (MessageProcessor processor : processors) {
-            if (processor.canProcess(ctx, session.getState())) {
-                processor.process(ctx, session.getState());
+            if (processor.canProcess(ctx, session)) {
+                processor.process(ctx, session);
             }
         }
     }

--- a/src/main/java/bot/core/model/messageProcessing/AddingInGroupMessageProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/AddingInGroupMessageProcessor.java
@@ -1,7 +1,7 @@
 package bot.core.model.messageProcessing;
 
 import bot.core.Main;
-import bot.core.control.SessionState;
+import bot.core.control.Session;
 import bot.core.model.Group;
 import bot.core.model.MessageContext;
 import bot.core.util.ChatUtils;
@@ -19,8 +19,8 @@ public class AddingInGroupMessageProcessor implements MessageProcessor {
 
     //Когда бота добавили в группу
     @Override
-    public boolean canProcess(MessageContext ctx, SessionState state) {
-        if (state.pendingGroupName == null) return false;
+    public boolean canProcess(MessageContext ctx, Session session) {
+        if (session.getState().pendingGroupName == null) return false;
 
         return ctx.isFromGroup() && isBotAddedToGroup(ctx);
     }
@@ -41,7 +41,7 @@ public class AddingInGroupMessageProcessor implements MessageProcessor {
 
 
     @Override
-    public void process(MessageContext ctx, SessionState state) {
+    public void process(MessageContext ctx, Session session) {
         long chatId = ctx.getChatId();
         log.info("Bot added to new group");
 
@@ -63,14 +63,14 @@ public class AddingInGroupMessageProcessor implements MessageProcessor {
                             "\nПожалуйста, просто используйте уже добавленный чат с помощью команды /set_group"
             );
 
-            state.cansel();
+            session.getState().cansel();
             return;
         }
 
         ChatUtils.sendInlineKeyboard(
                 chatId,
-                "Дайте боту права администратора в " + state.pendingGroupName + ".\nПосле нажмите кнопку подтверждения",
-                ChatUtils.getConfirmAdminStatusKeyboard(new Group(state.pendingGroupName, chatId))
+                "Дайте боту права администратора в " + session.getState().pendingGroupName + ".\nПосле нажмите кнопку подтверждения",
+                ChatUtils.getConfirmAdminStatusKeyboard(new Group(session.getState().pendingGroupName, chatId))
         );
     }
 }

--- a/src/main/java/bot/core/model/messageProcessing/CommandMessageProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/CommandMessageProcessor.java
@@ -1,7 +1,7 @@
 package bot.core.model.messageProcessing;
 
 import bot.core.control.CommandHandler;
-import bot.core.control.SessionState;
+import bot.core.control.Session;
 import bot.core.model.MessageContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,13 +10,13 @@ public class CommandMessageProcessor implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(EditInfoProcessor.class);
 
     @Override
-    public boolean canProcess(MessageContext message, SessionState state) {
+    public boolean canProcess(MessageContext message, Session session) {
         return message.isCommand();
     }
 
     @Override
-    public void process(MessageContext message, SessionState state) {
-        CommandHandler handler = new CommandHandler(state, message.getChatId());
+    public void process(MessageContext message, Session session) {
+        CommandHandler handler = new CommandHandler(session.getState(), message.getChatId());
         handler.handle(message);
     }
 }

--- a/src/main/java/bot/core/model/messageProcessing/CommonMessageProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/CommonMessageProcessor.java
@@ -1,6 +1,6 @@
 package bot.core.model.messageProcessing;
 
-import bot.core.control.SessionState;
+import bot.core.control.Session;
 import bot.core.model.MessageContext;
 import bot.core.util.ChatUtils;
 import bot.core.util.DataUtils;
@@ -15,23 +15,23 @@ public class CommonMessageProcessor implements MessageProcessor {
     Validator validator;
 
     @Override
-    public boolean canProcess(MessageContext ctx, SessionState state) {
+    public boolean canProcess(MessageContext ctx, Session session) {
         return !ctx.isFromGroup();
     }
 
     @Override
-    public void process(MessageContext ctx, SessionState state) {
+    public void process(MessageContext ctx, Session session) {
         long userId = ctx.getChatId();
         log.info("New message from {}", userId);
 
         if (ctx.hasPayment()) {
-            handlePayment(ctx);
+            handlePayment(ctx, session);
         } else {
             ChatUtils.sendMessage(userId, "Пожалуйста приложите документ или фото платежа");
         }
     }
 
-    private void handlePayment(MessageContext ctx, SessionState state) {
+    private void handlePayment(MessageContext ctx, Session session) {
         long userId = ctx.getChatId();
         log.info("New payment from {}", userId);
 

--- a/src/main/java/bot/core/model/messageProcessing/EditHelpProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/EditHelpProcessor.java
@@ -1,6 +1,6 @@
 package bot.core.model.messageProcessing;
 
-import bot.core.control.SessionState;
+import bot.core.control.Session;
 import bot.core.model.MessageContext;
 import bot.core.util.ChatUtils;
 import bot.core.util.DataUtils;
@@ -11,15 +11,15 @@ public class EditHelpProcessor implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(EditInfoProcessor.class);
 
     @Override
-    public boolean canProcess(MessageContext message, SessionState state) {
-        return state.isEditingHelp() && message.isFromAdmin() && !message.getText().equals("/cancel");
+    public boolean canProcess(MessageContext message, Session session) {
+        return session.getState().isEditingHelp() && message.isFromAdmin() && !message.getText().equals("/cancel");
     }
 
     @Override
-    public void process(MessageContext message, SessionState state) {
+    public void process(MessageContext message, Session session) {
         log.info("Editing help for chatId={}", message.getChatId());
         DataUtils.setInfo(message.getText());
-        state.editHelp();
+        session.getState().editHelp();
         ChatUtils.sendMessage(message.getChatId(), "Инструкция для пользователей изменена");
     }
 }

--- a/src/main/java/bot/core/model/messageProcessing/EditInfoProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/EditInfoProcessor.java
@@ -1,6 +1,6 @@
 package bot.core.model.messageProcessing;
 
-import bot.core.control.SessionState;
+import bot.core.control.Session;
 import bot.core.model.MessageContext;
 import bot.core.util.ChatUtils;
 import bot.core.util.DataUtils;
@@ -11,15 +11,15 @@ public class EditInfoProcessor implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(EditInfoProcessor.class);
 
     @Override
-    public boolean canProcess(MessageContext message, SessionState state) {
-        return state.isEditingInfo() && message.isFromAdmin() && !message.getText().equals("/cancel");
+    public boolean canProcess(MessageContext message, Session session) {
+        return session.getState().isEditingInfo() && message.isFromAdmin() && !message.getText().equals("/cancel");
     }
 
     @Override
-    public void process(MessageContext message, SessionState state) {
+    public void process(MessageContext message, Session session) {
         log.info("Editing info for chatId={}", message.getChatId());
         DataUtils.setInfo(message.getText());
-        state.editInfo();
+        session.getState().editInfo();
         ChatUtils.sendMessage(message.getChatId(), "Информация изменена");
     }
 }

--- a/src/main/java/bot/core/model/messageProcessing/HistoryForwardProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/HistoryForwardProcessor.java
@@ -1,16 +1,16 @@
 package bot.core.model.messageProcessing;
 
-import bot.core.control.SessionState;
+import bot.core.control.Session;
 import bot.core.model.MessageContext;
 
 public class HistoryForwardProcessor implements MessageProcessor {
     @Override
-    public boolean canProcess(MessageContext message, SessionState state) {
+    public boolean canProcess(MessageContext message, Session session) {
         return false;
     }
 
     @Override
-    public void process(MessageContext message, SessionState state) {
+    public void process(MessageContext message, Session session) {
 
     }
 }

--- a/src/main/java/bot/core/model/messageProcessing/MessageProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/MessageProcessor.java
@@ -2,9 +2,9 @@ package bot.core.model.messageProcessing;
 
 
 import bot.core.model.MessageContext;
-import bot.core.control.SessionState;
+import bot.core.control.Session;
 
 public interface MessageProcessor {
-    boolean canProcess(MessageContext message, SessionState state);
-    void process(MessageContext message, SessionState state);
+    boolean canProcess(MessageContext message, Session session);
+    void process(MessageContext message, Session session);
 }

--- a/src/main/java/bot/core/model/messageProcessing/SetGroupNameProcessor.java
+++ b/src/main/java/bot/core/model/messageProcessing/SetGroupNameProcessor.java
@@ -1,6 +1,6 @@
 package bot.core.model.messageProcessing;
 
-import bot.core.control.SessionState;
+import bot.core.control.Session;
 import bot.core.model.MessageContext;
 import bot.core.util.ChatUtils;
 import bot.core.util.GroupUtils;
@@ -21,12 +21,12 @@ public class SetGroupNameProcessor implements MessageProcessor {
 
 
     @Override
-    public boolean canProcess(MessageContext ctx, SessionState state) {
-        return state.isWaitingGroupName() && ctx.isFromAdmin() && !ctx.getText().equals("/cancel");
+    public boolean canProcess(MessageContext ctx, Session session) {
+        return session.getState().isWaitingGroupName() && ctx.isFromAdmin() && !ctx.getText().equals("/cancel");
     }
 
     @Override
-    public void process(MessageContext ctx, SessionState state) {
+    public void process(MessageContext ctx, Session session) {
         String name = ctx.getText();
         long chatId = ctx.getChatId();
 
@@ -42,9 +42,9 @@ public class SetGroupNameProcessor implements MessageProcessor {
             return;
         }
 
-        state.pendingGroupName = name.replace(" ", "-").replace("_", "-");
-        state.waitGroupName();
+        session.getState().pendingGroupName = name.replace(" ", "-").replace("_", "-");
+        session.getState().waitGroupName();
 
-        ChatUtils.sendMessage(ctx.getChatId(), String.format(GROUP_NAME_SETUP_INSTRUCTION, state.pendingGroupName));
+        ChatUtils.sendMessage(ctx.getChatId(), String.format(GROUP_NAME_SETUP_INSTRUCTION, session.getState().pendingGroupName));
     }
 }


### PR DESCRIPTION
## Summary
- refactor `MessageProcessor` interface to take `Session`
- update all processor implementations
- adjust bot to pass `Session` to processors

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684313101f74832a8bfc93a0183e6872