### PR TITLE
Switch group storage to Group objects

### DIFF
--- a/src/main/java/bot/core/control/handlers/CallbackHandler.java
+++ b/src/main/java/bot/core/control/handlers/CallbackHandler.java
@@ -80,7 +80,7 @@ public class CallbackHandler {
 
 
     private void handleDelGroupAction(long userId, int messageId, Long groupId) {
-        if (Main.dataUtils.getGroupMap().containsValue(groupId)) {
+        if (Main.dataUtils.containsGroupId(groupId)) {
             Main.dataUtils.removeGroup(groupId);
             ChatUtils.sendMessage(userId, "Группа удалена");
             ChatUtils.deleteMessage(userId, messageId);
@@ -140,7 +140,7 @@ public class CallbackHandler {
     private void handleSetGroupAction(Long selectedGroupId, long selectingUserId, int messageId) {
         log.info("User {} set group {}", selectingUserId, selectedGroupId);
 
-        if (!Main.dataUtils.getGroupMap().containsValue(selectedGroupId)) {
+        if (!Main.dataUtils.containsGroupId(selectedGroupId)) {
             ChatUtils.sendMessage(selectingUserId, "Группа не найдена");
             return;
         }

--- a/src/main/java/bot/core/control/handlers/CommandHandler.java
+++ b/src/main/java/bot/core/control/handlers/CommandHandler.java
@@ -221,7 +221,7 @@ public class CommandHandler {
     private void handleDelCommand() {
         log.info("user {} get /del command", userId);
 
-        if (Main.dataUtils.getGroupMap().isEmpty()) {
+        if (Main.dataUtils.getGroupList().isEmpty()) {
             ChatUtils.sendMessage(userId, "Не найдено ни одной группы");
             return;
         }

--- a/src/main/java/bot/core/control/messageProcessing/AddingInGroupMessageProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/AddingInGroupMessageProcessor.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.objects.ChatMemberUpdated;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.User;
+import bot.core.model.Group;
 
 import java.util.List;
 
@@ -77,7 +78,8 @@ public class AddingInGroupMessageProcessor implements MessageProcessor {
     }
 
     private boolean isItNewChat(String chatName, Long chatId) {
-        Long savedChatId = Main.dataUtils.getGroupMap().get(chatName);
+        Group group = Main.dataUtils.getGroupByName(chatName);
+        Long savedChatId = group == null ? null : group.getId();
         return savedChatId == null || savedChatId.equals(chatId);
     }
 

--- a/src/main/java/bot/core/model/Group.java
+++ b/src/main/java/bot/core/model/Group.java
@@ -1,6 +1,9 @@
 package bot.core.model;
 
-public class Group {
+import java.io.Serializable;
+
+public class Group implements Serializable {
+    private static final long serialVersionUID = 1L;
     long id;
     String name;
 

--- a/src/main/java/bot/core/util/ChatUtils.java
+++ b/src/main/java/bot/core/util/ChatUtils.java
@@ -17,6 +17,7 @@ import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import bot.core.model.Group;
 
 import java.util.*;
 
@@ -78,9 +79,9 @@ public final class ChatUtils {
     public static InlineKeyboardMarkup getAllGroupKeyboard(String callBack, Long userId) {
         List<InlineKeyboardButton> buttons = new ArrayList<>();
 
-        for (Map.Entry<String, Long> entry : Main.dataUtils.getGroupMap().entrySet()) {
-            String groupName = entry.getKey();
-            Long groupId = entry.getValue();
+        for (Group group : Main.dataUtils.getGroupList()) {
+            String groupName = group.getName();
+            Long groupId = group.getId();
 
             if (isBotAdminInGroup(groupId)) {
                 buttons.add(createButton(groupName, callBack + "_" + groupId));


### PR DESCRIPTION
## Summary
- store groups as a `List<Group>` instead of a `Map`
- adjust DataUtils to manage list of `Group`
- implement helper methods for group lookup
- update CommandHandler, CallbackHandler, AddingInGroupMessageProcessor and ChatUtils to use new API
- make `Group` serializable

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6862601a5d78832a9c1e34fa13e851c6