### PR TITLE
Refactor MessageProcessor API

### DIFF
--- a/src/main/java/bot/core/control/messageProcessing/AddingInGroupMessageProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/AddingInGroupMessageProcessor.java
@@ -1,8 +1,6 @@
 package bot.core.control.messageProcessing;
 
 import bot.core.Main;
-import bot.core.model.Session;
-import bot.core.model.MessageContext;
 import bot.core.util.ChatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,18 +9,10 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.api.objects.User;
 import bot.core.model.Group;
 
-import java.util.List;
-
 public class AddingInGroupMessageProcessor implements MessageProcessor {
     Logger log = LoggerFactory.getLogger(AddingInGroupMessageProcessor.class);
 
-
-    //поменять
     @Override
-    public boolean canProcess(MessageContext ctx, Session session) {
-        return false;
-    }
-
     public boolean canProcess(Update update) {
         return isBotAddedToGroup(update) && update.getMyChatMember().getFrom().getId() == Main.dataUtils.getAdminId();
     }
@@ -39,16 +29,9 @@ public class AddingInGroupMessageProcessor implements MessageProcessor {
     }
 
     @Override
-    public void process(MessageContext ctx, Session session) {
-        processChatAddition(
-                ctx.getChatId(),
-                ctx.getChatName(),
-                ctx.getFromId(),
-                ctx.getMessage().getChat().getType()
-        );
-    }
-
-    public void process(ChatMemberUpdated myChatMember) {
+    public void process(Update update) {
+        if (!update.hasMyChatMember()) return;
+        ChatMemberUpdated myChatMember = update.getMyChatMember();
         processChatAddition(
                 myChatMember.getChat().getId(),
                 myChatMember.getChat().getTitle(),

--- a/src/main/java/bot/core/control/messageProcessing/CommandMessageProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/CommandMessageProcessor.java
@@ -1,21 +1,25 @@
 package bot.core.control.messageProcessing;
 
 import bot.core.control.handlers.CommandHandler;
-import bot.core.model.Session;
 import bot.core.model.MessageContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import bot.core.control.SessionController;
+import bot.core.model.Session;
+import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class CommandMessageProcessor implements MessageProcessor {
-    private static final Logger log = LoggerFactory.getLogger(EditInfoProcessor.class);
 
     @Override
-    public boolean canProcess(MessageContext message, Session session) {
+    public boolean canProcess(Update update) {
+        if (!update.hasMessage()) return false;
+        MessageContext message = new MessageContext(update.getMessage());
         return message.isCommand();
     }
 
     @Override
-    public void process(MessageContext message, Session session) {
+    public void process(Update update) {
+        MessageContext message = new MessageContext(update.getMessage());
+        Session session = SessionController.getInstance()
+                .openSessionIfNeeded(update.getMessage().getFrom());
         CommandHandler handler = new CommandHandler(session.getState(), message.getFromId());
         handler.handle(message);
     }

--- a/src/main/java/bot/core/control/messageProcessing/CommonMessageProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/CommonMessageProcessor.java
@@ -1,8 +1,10 @@
 package bot.core.control.messageProcessing;
 
 import bot.core.Main;
+import bot.core.control.SessionController;
 import bot.core.model.Session;
 import bot.core.model.MessageContext;
+import org.telegram.telegrambots.meta.api.objects.Update;
 import bot.core.util.ChatUtils;
 import bot.core.control.Validator;
 import org.slf4j.Logger;
@@ -13,14 +15,24 @@ public class CommonMessageProcessor implements MessageProcessor {
     Validator validator;
 
     @Override
-    public boolean canProcess(MessageContext ctx, Session session) {
+    public boolean canProcess(Update update) {
+        if (!update.hasMessage()) return false;
+        MessageContext ctx = new MessageContext(update.getMessage());
+        Session session = SessionController.getInstance()
+                .openSessionIfNeeded(update.getMessage().getFrom());
         //todo проверить
         return !ctx.isCommand() && !ctx.isFromGroup() && session.getState().isCommonState();
     }
 
     @Override
-    public void process(MessageContext ctx, Session session) {
+    public void process(Update update) {
+        if (!update.hasMessage()) return;
         if (validator == null) validator = new Validator();
+
+        MessageContext ctx = new MessageContext(update.getMessage());
+        Session session = SessionController.getInstance()
+                .getUserSession(ctx.getFromId());
+
         long userId = ctx.getChatId();
 
         if (ctx.hasPayment()) {

--- a/src/main/java/bot/core/control/messageProcessing/EditHelpProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/EditHelpProcessor.java
@@ -2,21 +2,27 @@ package bot.core.control.messageProcessing;
 
 import bot.core.model.Session;
 import bot.core.model.MessageContext;
+import bot.core.control.SessionController;
 import bot.core.util.ChatUtils;
 import bot.core.Main;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class EditHelpProcessor implements MessageProcessor {
-    private static final Logger log = LoggerFactory.getLogger(EditInfoProcessor.class);
 
     @Override
-    public boolean canProcess(MessageContext message, Session session) {
+    public boolean canProcess(Update update) {
+        if (!update.hasMessage()) return false;
+        MessageContext message = new MessageContext(update.getMessage());
+        Session session = SessionController.getInstance()
+                .openSessionIfNeeded(update.getMessage().getFrom());
         return session.getState().isEditingHelp() && message.isFromAdmin() && !message.getText().equals("/cancel");
     }
 
     @Override
-    public void process(MessageContext message, Session session) {
+    public void process(Update update) {
+        if (!update.hasMessage()) return;
+        MessageContext message = new MessageContext(update.getMessage());
+        Session session = SessionController.getInstance().getUserSession(message.getFromId());
         Main.dataUtils.setHelp(message.getText());
         session.getState().cansel();
         ChatUtils.sendMessage(message.getChatId(), "Инструкция для пользователей изменена");

--- a/src/main/java/bot/core/control/messageProcessing/EditInfoProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/EditInfoProcessor.java
@@ -2,21 +2,27 @@ package bot.core.control.messageProcessing;
 
 import bot.core.model.Session;
 import bot.core.model.MessageContext;
+import bot.core.control.SessionController;
 import bot.core.util.ChatUtils;
 import bot.core.Main;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class EditInfoProcessor implements MessageProcessor {
-    private static final Logger log = LoggerFactory.getLogger(EditInfoProcessor.class);
 
     @Override
-    public boolean canProcess(MessageContext message, Session session) {
+    public boolean canProcess(Update update) {
+        if (!update.hasMessage()) return false;
+        MessageContext message = new MessageContext(update.getMessage());
+        Session session = SessionController.getInstance()
+                .openSessionIfNeeded(update.getMessage().getFrom());
         return session.getState().isEditingInfo() && message.isFromAdmin() && !message.getText().equals("/cancel");
     }
 
     @Override
-    public void process(MessageContext message, Session session) {
+    public void process(Update update) {
+        if (!update.hasMessage()) return;
+        MessageContext message = new MessageContext(update.getMessage());
+        Session session = SessionController.getInstance().getUserSession(message.getFromId());
         Main.dataUtils.setInfo(message.getText());
         session.getState().cansel();
         ChatUtils.sendMessage(message.getChatId(), "Информация изменена");

--- a/src/main/java/bot/core/control/messageProcessing/EditPaymentInfoProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/EditPaymentInfoProcessor.java
@@ -3,16 +3,25 @@ package bot.core.control.messageProcessing;
 import bot.core.Main;
 import bot.core.model.Session;
 import bot.core.model.MessageContext;
+import bot.core.control.SessionController;
 import bot.core.util.ChatUtils;
+import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class EditPaymentInfoProcessor implements MessageProcessor {
     @Override
-    public boolean canProcess(MessageContext message, Session session) {
+    public boolean canProcess(Update update) {
+        if (!update.hasMessage()) return false;
+        MessageContext message = new MessageContext(update.getMessage());
+        Session session = SessionController.getInstance()
+                .openSessionIfNeeded(update.getMessage().getFrom());
         return message.isFromAdmin() && session.getState().isEditPaymentInfo();
     }
 
     @Override
-    public void process(MessageContext message, Session session) {
+    public void process(Update update) {
+        if (!update.hasMessage()) return;
+        MessageContext message = new MessageContext(update.getMessage());
+        Session session = SessionController.getInstance().getUserSession(message.getFromId());
         Main.dataUtils.setPaymentInfo(message.getText());
         session.getState().cansel();
         ChatUtils.sendMessage(message.getFromId(), "Информация об оплате изменена");

--- a/src/main/java/bot/core/control/messageProcessing/MessageProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/MessageProcessor.java
@@ -1,10 +1,9 @@
 package bot.core.control.messageProcessing;
 
 
-import bot.core.model.MessageContext;
-import bot.core.model.Session;
+import org.telegram.telegrambots.meta.api.objects.Update;
 
 public interface MessageProcessor {
-    boolean canProcess(MessageContext message, Session session);
-    void process(MessageContext message, Session session);
+    boolean canProcess(Update update);
+    void process(Update update);
 }


### PR DESCRIPTION
## Summary
- change `MessageProcessor` to accept `Update`
- update all message processors to fetch `Session` via `SessionController`
- adapt bot logic to new processor API

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686295b70158832a9de8ae7e7cb9810c