### PR TITLE
Refactor callback processing

### DIFF
--- a/src/main/java/bot/core/control/callbackHandlers/ConfirmHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/ConfirmHandler.java
@@ -1,0 +1,59 @@
+package bot.core.control.callbackHandlers;
+
+import bot.core.control.SessionController;
+import bot.core.control.TimerController;
+import bot.core.util.ChatUtils;
+import bot.core.Main;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class ConfirmHandler implements callbackHandler {
+    private static final Logger log = LoggerFactory.getLogger(ConfirmHandler.class);
+
+    @Override
+    public boolean match(Update update) {
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("confirm_");
+    }
+
+    @Override
+    public boolean isFormatCorrect(String callback) {
+        String[] data = callback.split("_");
+        if (data.length != 3) return false;
+        try {
+            Integer.parseInt(data[1]);
+            Long.parseLong(data[2]);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean handle(Update update) {
+        CallbackQuery cq = update.getCallbackQuery();
+        String[] data = cq.getData().split("_");
+        int originMessageId = Integer.parseInt(data[1]);
+        long targetUserId = Long.parseLong(data[2]);
+        long chatId = cq.getMessage().getChatId();
+        int messageId = cq.getMessage().getMessageId();
+
+        log.info("Admin {} confirm {}", chatId, targetUserId);
+        Long groupId = SessionController.getInstance().getUserSession(targetUserId).getGroupId();
+        if (TimerController.hasTimer(targetUserId, groupId)) {
+            TimerController.stopTimer(targetUserId, groupId);
+            ChatUtils.addInGroup(targetUserId, groupId, "Одобрение админа");
+        } else {
+            log.info("Already added by timer");
+        }
+        ChatUtils.deleteMessage(chatId, messageId);
+        ChatUtils.deleteMessage(chatId, originMessageId);
+        return true;
+    }
+
+    @Override
+    public String getFormat() {
+        return "confirm_<messageId>_<userId>";
+    }
+}

--- a/src/main/java/bot/core/control/callbackHandlers/DeclineHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/DeclineHandler.java
@@ -1,0 +1,124 @@
+package bot.core.control.callbackHandlers;
+
+import bot.core.Main;
+import bot.core.control.SessionController;
+import bot.core.control.TimerController;
+import bot.core.util.ChatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.methods.groupadministration.BanChatMember;
+import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChatMember;
+import org.telegram.telegrambots.meta.api.methods.groupadministration.UnbanChatMember;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiRequestException;
+
+import java.time.Instant;
+
+public class DeclineHandler implements callbackHandler {
+    private static final Logger log = LoggerFactory.getLogger(DeclineHandler.class);
+
+    @Override
+    public boolean match(Update update) {
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("decline_");
+    }
+
+    @Override
+    public boolean isFormatCorrect(String callback) {
+        String[] data = callback.split("_");
+        if (data.length != 3) return false;
+        try {
+            Integer.parseInt(data[1]);
+            Long.parseLong(data[2]);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean handle(Update update) {
+        CallbackQuery cq = update.getCallbackQuery();
+        String[] data = cq.getData().split("_");
+        int originMessageId = Integer.parseInt(data[1]);
+        long targetUserId = Long.parseLong(data[2]);
+        long chatId = cq.getMessage().getChatId();
+        int messageId = cq.getMessage().getMessageId();
+
+        ChatUtils.deleteMessage(chatId, messageId);
+        ChatUtils.deleteMessage(chatId, originMessageId);
+        handleDeclineAction(targetUserId);
+        return true;
+    }
+
+    private void handleDeclineAction(long targetUserId) {
+        long groupId = SessionController.getInstance().getUserSession(targetUserId).getGroupId();
+        String userName = SessionController.getInstance()
+                .getUserSession(targetUserId)
+                .getUserName();
+        String groupName = Main.dataUtils.getGroupName(groupId);
+
+        try {
+            if (TimerController.hasTimer(targetUserId, groupId)) {
+                ChatUtils.sendMessage(targetUserId, "Ваша заявка была отклонена, \n" +
+                        "вы можете создать еще одну заявку или обратиться к администратору @Tulasikl");
+                ChatUtils.sendMessage(Long.parseLong(Main.dataUtils.getHistoryId()),
+                        "Заявка пользователя @" +
+                                userName +
+                                " была отклонена, \n" +
+                                "Он хотел попасть в группу " + groupName);
+                TimerController.stopTimer(targetUserId, groupId);
+            } else {
+                if (areUserInGroup(targetUserId, groupId)) {
+                    BanChatMember ban = new BanChatMember();
+                    ban.setChatId(String.valueOf(groupId));
+                    ban.setUserId(targetUserId);
+                    ban.setUntilDate((int) Instant.now().getEpochSecond() + 60);
+                    Main.bot.execute(ban);
+
+                    UnbanChatMember unban = new UnbanChatMember();
+                    unban.setChatId(String.valueOf(groupId));
+                    unban.setUserId(targetUserId);
+                    Main.bot.execute(unban);
+                    log.info("User {} was kicked from group {}", userName, groupId);
+
+                    ChatUtils.sendMessage(Long.parseLong(Main.dataUtils.getHistoryId()),
+                            "Пользователь @" + userName + " был удален из группы " + groupName);
+
+                    ChatUtils.sendMessage(targetUserId, "Вы были удалены из группы " + groupName + "\n" +
+                            "вы можете создать еще одну заявку или обратиться к администратору @Tulasikl");
+                } else {
+                    log.info("User {} already isn’t a member of group {}", targetUserId, groupId);
+                }
+            }
+        } catch (TelegramApiRequestException e) {
+            log.error("UnbanChatMember Bad Request: method is available for supergroup and channel chats only");
+        } catch (TelegramApiException e) {
+            log.error("Can’t remove user {} from group {}", targetUserId, groupId);
+        }
+    }
+
+    private boolean areUserInGroup(long userId, long groupId) {
+        try {
+            GetChatMember getChatMember = new GetChatMember();
+            getChatMember.setChatId(groupId);
+            getChatMember.setUserId(userId);
+            ChatMember chatMember = Main.bot.execute(getChatMember);
+            String status = chatMember.getStatus();
+            return status.equals("member")
+                    || status.equals("administrator")
+                    || status.equals("creator")
+                    || status.equals("restricted");
+        } catch (TelegramApiException e) {
+            log.warn("Не удалось получить статус пользователя в избранной группе {} ", userId);
+        }
+        return false;
+    }
+
+    @Override
+    public String getFormat() {
+        return "decline_<messageId>_<userId>";
+    }
+}

--- a/src/main/java/bot/core/control/callbackHandlers/DelGroupHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/DelGroupHandler.java
@@ -1,0 +1,48 @@
+package bot.core.control.callbackHandlers;
+
+import bot.core.Main;
+import bot.core.util.ChatUtils;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class DelGroupHandler implements callbackHandler {
+    @Override
+    public boolean match(Update update) {
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("delGroup_");
+    }
+
+    @Override
+    public boolean isFormatCorrect(String callback) {
+        String[] data = callback.split("_");
+        if (data.length != 2) return false;
+        try {
+            Long.parseLong(data[1]);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean handle(Update update) {
+        CallbackQuery cq = update.getCallbackQuery();
+        String[] data = cq.getData().split("_");
+        Long groupId = Long.parseLong(data[1]);
+        long userId = cq.getMessage().getChatId();
+        int messageId = cq.getMessage().getMessageId();
+
+        if (Main.dataUtils.containsGroupId(groupId)) {
+            Main.dataUtils.removeGroup(groupId);
+            ChatUtils.sendMessage(userId, "Группа удалена");
+            ChatUtils.deleteMessage(userId, messageId);
+        } else {
+            ChatUtils.sendMessage(userId, "Группа не найдена");
+        }
+        return true;
+    }
+
+    @Override
+    public String getFormat() {
+        return "delGroup_<groupId>";
+    }
+}

--- a/src/main/java/bot/core/control/callbackHandlers/GetJoinRequestedLinkHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/GetJoinRequestedLinkHandler.java
@@ -1,0 +1,36 @@
+package bot.core.control.callbackHandlers;
+
+import bot.core.util.ChatUtils;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class GetJoinRequestedLinkHandler implements callbackHandler {
+    @Override
+    public boolean match(Update update) {
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("getJoinRequestedLink_");
+    }
+
+    @Override
+    public boolean isFormatCorrect(String callback) {
+        String[] data = callback.split("_");
+        return data.length >= 3; // link may contain underscores
+    }
+
+    @Override
+    public boolean handle(Update update) {
+        CallbackQuery cq = update.getCallbackQuery();
+        String[] data = cq.getData().split("_", 3);
+        String link = data[1];
+        long chatId = Long.parseLong(data[2]);
+        ChatUtils.sendMessage(chatId,
+                "Если вы уже вступили в группу, но не можете её найти — воспользуйтесь ссылкой ниже.\n\n" +
+                        "⚠️ Внимание: если вы ещё не вступали в группу, сначала перейдите по одноразовой ссылке выше.\n" +
+                        link);
+        return true;
+    }
+
+    @Override
+    public String getFormat() {
+        return "getJoinRequestedLink_<link>_<chatId>";
+    }
+}

--- a/src/main/java/bot/core/control/callbackHandlers/SetGroupHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/SetGroupHandler.java
@@ -1,0 +1,85 @@
+package bot.core.control.callbackHandlers;
+
+import bot.core.Main;
+import bot.core.control.SessionController;
+import bot.core.util.ChatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+public class SetGroupHandler implements callbackHandler {
+    private static final Logger log = LoggerFactory.getLogger(SetGroupHandler.class);
+
+    @Override
+    public boolean match(Update update) {
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("setGroup_");
+    }
+
+    @Override
+    public boolean isFormatCorrect(String callback) {
+        String[] data = callback.split("_");
+        if (data.length != 2) return false;
+        try {
+            Long.parseLong(data[1]);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean handle(Update update) {
+        CallbackQuery cq = update.getCallbackQuery();
+        String[] data = cq.getData().split("_");
+        Long groupId = Long.parseLong(data[1]);
+        long userId = cq.getMessage().getChatId();
+        int messageId = cq.getMessage().getMessageId();
+
+        log.info("User {} set group {}", userId, groupId);
+
+        if (!Main.dataUtils.containsGroupId(groupId)) {
+            ChatUtils.sendMessage(userId, "Группа не найдена");
+            return true;
+        }
+        String groupName = Main.dataUtils.getGroupName(groupId);
+
+        if (ChatUtils.isBotAdminInGroup(groupId)) {
+            if (isItFavoriteUser(userId)) {
+                ChatUtils.addInGroup(userId, groupId, "Член избранной группы");
+            } else {
+                SessionController.getInstance().setUserGroupId(userId, groupId);
+                ChatUtils.sendMessage(userId, "Выбрана группа: " + groupName + "\nТеперь пришлите подтверждение оплаты");
+            }
+        } else {
+            ChatUtils.sendMessage(userId, "Бот не выходит в группу или не является в ней администратором");
+        }
+        return true;
+    }
+
+    private boolean isItFavoriteUser(Long userId) {
+        return areUserInGroup(userId, Main.dataUtils.getFavoriteGroupId());
+    }
+
+    private boolean areUserInGroup(long userId, long groupId) {
+        try {
+            org.telegram.telegrambots.meta.api.methods.groupadministration.GetChatMember getChatMember = new org.telegram.telegrambots.meta.api.methods.groupadministration.GetChatMember();
+            getChatMember.setChatId(groupId);
+            getChatMember.setUserId(userId);
+            org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember chatMember = Main.bot.execute(getChatMember);
+            String status = chatMember.getStatus();
+            return status.equals("member")
+                    || status.equals("administrator")
+                    || status.equals("creator")
+                    || status.equals("restricted");
+        } catch (org.telegram.telegrambots.meta.exceptions.TelegramApiException e) {
+            log.warn("Не удалось получить статус пользователя в избранной группе {} ", userId);
+        }
+        return false;
+    }
+
+    @Override
+    public String getFormat() {
+        return "setGroup_<groupId>";
+    }
+}

--- a/src/main/java/bot/core/control/callbackHandlers/SetTagHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/SetTagHandler.java
@@ -1,0 +1,56 @@
+package bot.core.control.callbackHandlers;
+
+import bot.core.Main;
+import bot.core.util.ChatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.Map;
+
+public class SetTagHandler implements callbackHandler {
+    private static final Logger log = LoggerFactory.getLogger(SetTagHandler.class);
+
+    @Override
+    public boolean match(Update update) {
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("setTag_");
+    }
+
+    @Override
+    public boolean isFormatCorrect(String callback) {
+        String[] data = callback.split("_");
+        if (data.length != 2) return false;
+        try {
+            Integer.parseInt(data[1]);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean handle(Update update) {
+        CallbackQuery cq = update.getCallbackQuery();
+        String[] data = cq.getData().split("_");
+        String tagId = data[1];
+        long userId = cq.getMessage().getChatId();
+        int messageId = cq.getMessage().getMessageId();
+
+        Map<Integer, String> tags = Main.dataUtils.getTagMap();
+        String tag = tags.get(Integer.parseInt(tagId));
+        if (tag == null) {
+            log.error("Попытка прочитать несуществующий тег {} ", tagId);
+            return true;
+        }
+        log.info("User {} set tag {}", userId, tag);
+        Main.dataUtils.setGroupTag(tag);
+        ChatUtils.deleteMessage(userId, messageId);
+        return true;
+    }
+
+    @Override
+    public String getFormat() {
+        return "setTag_<tagId>";
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `CallbackProcessor` so it iterates over callback handlers
- implement several handlers for different callback types

## Testing
- `mvn test` *(fails: Could not transfer artifact maven-resources-plugin from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6862ea461c4c832a90516d42405cb07b