### PR TITLE
Refactor callback data generation

### DIFF
--- a/src/main/java/bot/core/control/callbackHandlers/ChooseCourseHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/ChooseCourseHandler.java
@@ -2,6 +2,8 @@ package bot.core.control.callbackHandlers;
 
 import bot.core.Main;
 import bot.core.util.ChatUtils;
+import bot.core.control.callbackHandlers.Action;
+import bot.core.control.callbackHandlers.AbstractCallbackHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -9,26 +11,15 @@ import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMa
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 
-public class ChooseCourseHandler implements CallbackHandler {
+public class ChooseCourseHandler extends AbstractCallbackHandler {
     Logger log = LoggerFactory.getLogger(ChooseCourseHandler.class);
-    @Override
-    public boolean match(Update update) {
-        if (!update.hasCallbackQuery()) return false;
-        String[] data = update.getCallbackQuery().getData().split("_");
-        String action = data[0];
-        return action.equalsIgnoreCase("chooseCourse");
-    }
 
-    @Override
-    public boolean isFormatCorrect(String callback) {
-        String[] data = callback.split("_");
-        String action = data[0];
-        return data.length == 2 && action.equalsIgnoreCase("chooseCourse");
+    public ChooseCourseHandler() {
+        super(Action.chooseCourse, 2);
     }
 
     @Override
@@ -37,7 +28,7 @@ public class ChooseCourseHandler implements CallbackHandler {
         List<List<InlineKeyboardButton>> buttonRows = new ArrayList<>();
         for (Map.Entry<Integer, String> entry : tagMap.entrySet()) {
             InlineKeyboardButton button = new InlineKeyboardButton(entry.getValue());
-            button.setCallbackData("chooseTag_"  + entry.getKey());
+            button.setCallbackData(Action.chooseTag.toString() + "_"  + entry.getKey());
         }
         InlineKeyboardMarkup keyboardMarkup = new InlineKeyboardMarkup();
         keyboardMarkup.setKeyboard(buttonRows);
@@ -48,8 +39,4 @@ public class ChooseCourseHandler implements CallbackHandler {
                 keyboardMarkup);
     }
 
-    @Override
-    public String getFormat() {
-        return "chooseCourse_<chatId>";
-    }
 }

--- a/src/main/java/bot/core/control/callbackHandlers/ChooseTagHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/ChooseTagHandler.java
@@ -1,6 +1,7 @@
 package bot.core.control.callbackHandlers;
 
 import bot.core.util.ChatUtils;
+import bot.core.control.callbackHandlers.Action;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -17,13 +18,13 @@ public class ChooseTagHandler implements CallbackHandler {
         if (!update.hasCallbackQuery()) return false;
         String[] data = update.getCallbackQuery().getData().split("_");
         String action = data[0];
-        return action.equalsIgnoreCase("chooseTag");
+        return action.equalsIgnoreCase(Action.chooseTag.toString());
     }
 
     @Override
     public boolean isFormatCorrect(String callback) {
         String[] data = callback.split("_");
-        return data.length == 2 && data[0].equalsIgnoreCase("chooseTag");
+        return data.length == 2 && data[0].equalsIgnoreCase(Action.chooseTag.toString());
     }
 
     @Override
@@ -37,7 +38,7 @@ public class ChooseTagHandler implements CallbackHandler {
         ChatUtils.sendInlineKeyboard(
                 user.getId(),
                 "Выберете интересующую вас группу",
-                ChatUtils.getTaggedGroupKeyboard("setGroup", user.getId(), tag));
+                ChatUtils.getTaggedGroupKeyboard(Action.setGroup.toString(), user.getId(), tag));
     }
 
     @Override

--- a/src/main/java/bot/core/control/callbackHandlers/ConfirmHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/ConfirmHandler.java
@@ -3,6 +3,7 @@ package bot.core.control.callbackHandlers;
 import bot.core.control.SessionController;
 import bot.core.control.TimerController;
 import bot.core.util.ChatUtils;
+import bot.core.control.callbackHandlers.Action;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
@@ -13,13 +14,14 @@ public class ConfirmHandler implements CallbackHandler {
 
     @Override
     public boolean match(Update update) {
-        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("confirm_");
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith(Action.confirm.toString() + "_");
     }
 
     @Override
     public boolean isFormatCorrect(String callback) {
         String[] data = callback.split("_");
         if (data.length != 3) return false;
+        if (!data[0].equalsIgnoreCase(Action.confirm.toString())) return false;
         try {
             Integer.parseInt(data[1]);
             Long.parseLong(data[2]);

--- a/src/main/java/bot/core/control/callbackHandlers/DeclineHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/DeclineHandler.java
@@ -4,6 +4,7 @@ import bot.core.Main;
 import bot.core.control.SessionController;
 import bot.core.control.TimerController;
 import bot.core.util.ChatUtils;
+import bot.core.control.callbackHandlers.Action;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.methods.groupadministration.BanChatMember;
@@ -27,13 +28,14 @@ public class DeclineHandler implements CallbackHandler {
 
     @Override
     public boolean match(Update update) {
-        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("decline_");
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith(Action.decline.toString() + "_");
     }
 
     @Override
     public boolean isFormatCorrect(String callback) {
         String[] data = callback.split("_");
         if (data.length != 3) return false;
+        if (!data[0].equalsIgnoreCase(Action.decline.toString())) return false;
         try {
             Integer.parseInt(data[1]);
             Long.parseLong(data[2]);

--- a/src/main/java/bot/core/control/callbackHandlers/DelGroupHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/DelGroupHandler.java
@@ -2,19 +2,21 @@ package bot.core.control.callbackHandlers;
 
 import bot.core.Main;
 import bot.core.util.ChatUtils;
+import bot.core.control.callbackHandlers.Action;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class DelGroupHandler implements CallbackHandler {
     @Override
     public boolean match(Update update) {
-        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("delGroup_");
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith(Action.delGroup.toString() + "_");
     }
 
     @Override
     public boolean isFormatCorrect(String callback) {
         String[] data = callback.split("_");
         if (data.length != 2) return false;
+        if (!data[0].equalsIgnoreCase(Action.delGroup.toString())) return false;
         try {
             Long.parseLong(data[1]);
             return true;

--- a/src/main/java/bot/core/control/callbackHandlers/GetJoinRequestedLinkHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/GetJoinRequestedLinkHandler.java
@@ -1,19 +1,20 @@
 package bot.core.control.callbackHandlers;
 
 import bot.core.util.ChatUtils;
+import bot.core.control.callbackHandlers.Action;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class GetJoinRequestedLinkHandler implements CallbackHandler {
     @Override
     public boolean match(Update update) {
-        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("getJoinRequestedLink_");
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith(Action.getJoinRequestedLink.toString() + "_");
     }
 
     @Override
     public boolean isFormatCorrect(String callback) {
         String[] data = callback.split("_");
-        return data.length >= 3; // link may contain underscores
+        return data.length >= 3 && data[0].equalsIgnoreCase(Action.getJoinRequestedLink.toString()); // link may contain underscores
     }
 
     @Override

--- a/src/main/java/bot/core/control/callbackHandlers/SetGroupHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/SetGroupHandler.java
@@ -3,6 +3,7 @@ package bot.core.control.callbackHandlers;
 import bot.core.Main;
 import bot.core.control.SessionController;
 import bot.core.util.ChatUtils;
+import bot.core.control.callbackHandlers.Action;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
@@ -18,13 +19,14 @@ public class SetGroupHandler implements CallbackHandler {
 
     @Override
     public boolean match(Update update) {
-        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("setGroup_");
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith(Action.setGroup.toString() + "_");
     }
 
     @Override
     public boolean isFormatCorrect(String callback) {
         String[] data = callback.split("_");
         if (data.length != 2) return false;
+        if (!data[0].equalsIgnoreCase(Action.setGroup.toString())) return false;
         try {
             Long.parseLong(data[1]);
             return true;

--- a/src/main/java/bot/core/control/callbackHandlers/SetTagHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/SetTagHandler.java
@@ -2,6 +2,7 @@ package bot.core.control.callbackHandlers;
 
 import bot.core.Main;
 import bot.core.util.ChatUtils;
+import bot.core.control.callbackHandlers.Action;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
@@ -19,13 +20,14 @@ public class SetTagHandler implements CallbackHandler {
 
     @Override
     public boolean match(Update update) {
-        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith("setTag_");
+        return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith(Action.setTag.toString() + "_");
     }
 
     @Override
     public boolean isFormatCorrect(String callback) {
         String[] data = callback.split("_");
         if (data.length != 2) return false;
+        if (!data[0].equalsIgnoreCase(Action.setTag.toString())) return false;
         try {
             Integer.parseInt(data[1]);
             return true;

--- a/src/main/java/bot/core/control/messageProcessing/CommandMessageProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/CommandMessageProcessor.java
@@ -7,6 +7,7 @@ import bot.core.control.SessionController;
 import bot.core.model.Session;
 import bot.core.model.SessionState;
 import bot.core.util.ChatUtils;
+import bot.core.control.callbackHandlers.Action;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChat;
@@ -161,7 +162,7 @@ public class CommandMessageProcessor implements MessageProcessor {
 
         private void handleSetGroupCommand() {
             log.info("User {} set group", userId);
-            InlineKeyboardMarkup allGroupKeyboard = ChatUtils.getAllGroupKeyboard("setGroup", userId);
+            InlineKeyboardMarkup allGroupKeyboard = ChatUtils.getAllGroupKeyboard(Action.setGroup.toString(), userId);
 
             if (allGroupKeyboard.getKeyboard().isEmpty()) {
                 ChatUtils.sendMessage(userId, "Нет доступных групп");
@@ -177,7 +178,7 @@ public class CommandMessageProcessor implements MessageProcessor {
 
         private void handleSetTagCommand() {
             log.info("User {} use set_tag command", userId);
-            InlineKeyboardMarkup allTagKeyboard = ChatUtils.getAllTagKeyboard("setTag", userId);
+            InlineKeyboardMarkup allTagKeyboard = ChatUtils.getAllTagKeyboard(Action.setTag.toString(), userId);
 
             ChatUtils.sendInlineKeyboard(userId,
                     "Установите тег который будет присваиваться всем добавленным далее группам/каналам",
@@ -259,7 +260,7 @@ public class CommandMessageProcessor implements MessageProcessor {
                 return;
             }
 
-            InlineKeyboardMarkup allGroupKeyboard = ChatUtils.getAllGroupKeyboard("delGroup" ,userId);
+            InlineKeyboardMarkup allGroupKeyboard = ChatUtils.getAllGroupKeyboard(Action.delGroup.toString(), userId);
             ChatUtils.sendInlineKeyboard(userId, "Выберете группу для удаления", allGroupKeyboard);
         }
 

--- a/src/main/java/bot/core/util/ChatUtils.java
+++ b/src/main/java/bot/core/util/ChatUtils.java
@@ -2,6 +2,7 @@ package bot.core.util;
 
 import bot.core.Main;
 import bot.core.control.SessionController;
+import bot.core.control.callbackHandlers.Action;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.telegram.telegrambots.meta.api.methods.groupadministration.CreateChatInviteLink;
@@ -57,10 +58,10 @@ public final class ChatUtils {
         coursesDescription.setCallbackData("getCourseDescription_" + chatId);
 
         InlineKeyboardButton getInstruction = new InlineKeyboardButton("Инструкция");
-        getInstruction.setCallbackData("getInstruction_" + chatId);
+        getInstruction.setCallbackData(Action.getInstruction.toString() + "_" + chatId);
 
         InlineKeyboardButton chooseCourse = new InlineKeyboardButton("Выбрать курс");
-        chooseCourse.setCallbackData("chooseCourse_" + chatId);
+        chooseCourse.setCallbackData(Action.chooseCourse.toString() + "_" + chatId);
 
         List<List<InlineKeyboardButton>> rows = new ArrayList<>();
         rows.add(Arrays.asList(coursesDescription, getInstruction));
@@ -144,7 +145,7 @@ public final class ChatUtils {
      * Callback format: {@code confirm_<messageId>_<userId>}.
      */
     private static InlineKeyboardButton createConfirmButton(int messageId, long userId) {
-        return createButton("Принимаю", "confirm_" + messageId + "_" + userId);
+        return createButton("Принимаю", Action.confirm.toString() + "_" + messageId + "_" + userId);
     }
 
     /**
@@ -152,7 +153,7 @@ public final class ChatUtils {
      * Callback format: {@code decline_<messageId>_<userId>}.
      */
     private static InlineKeyboardButton createDeclineButton(int messageId, long userId) {
-        return createButton("Отказываю", "decline_" + messageId + "_" + userId);
+        return createButton("Отказываю", Action.decline.toString() + "_" + messageId + "_" + userId);
     }
 
     private static int getColumnCount(int size) {
@@ -284,7 +285,7 @@ public final class ChatUtils {
 
         InlineKeyboardButton button = new InlineKeyboardButton();
         button.setText("Я вступил, но не могу найти группу");
-        button.setCallbackData("getJoinRequestedLink_"
+        button.setCallbackData(Action.getJoinRequestedLink.toString() + "_"
                 + getJoinRequestedLink(groupId, groupName) + "_"
                 + userId);
 


### PR DESCRIPTION
## Summary
- reference the `Action` enum whenever setting callback data
- ensure callback handlers parse using `Action`
- extend `ChooseCourseHandler` from `AbstractCallbackHandler`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6862ff1641e0832a820bafeb7a45e29b