### PR TITLE
Add action mapping for callback handlers

### DIFF
--- a/src/main/java/bot/core/control/callbackHandlers/AbstractCallbackHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/AbstractCallbackHandler.java
@@ -18,6 +18,11 @@ public abstract class AbstractCallbackHandler implements CallbackHandler {
     }
 
     @Override
+    public Action getAction() {
+        return action;
+    }
+
+    @Override
     public boolean match(Update update) {
         if (!update.hasCallbackQuery()) return false;
         return update.getCallbackQuery().getData().startsWith(action.toString());

--- a/src/main/java/bot/core/control/callbackHandlers/CallbackHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/CallbackHandler.java
@@ -3,8 +3,9 @@ package bot.core.control.callbackHandlers;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 public interface CallbackHandler {
-    public String getFormat();
-    public boolean match(Update update);
-    public boolean isFormatCorrect(String callback);
-    public void handle(Update update);
+    Action getAction();
+    String getFormat();
+    boolean match(Update update);
+    boolean isFormatCorrect(String callback);
+    void handle(Update update);
 }

--- a/src/main/java/bot/core/control/callbackHandlers/ChooseGroupHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/ChooseGroupHandler.java
@@ -13,10 +13,16 @@ import org.telegram.telegrambots.meta.api.objects.Update;
  */
 public class ChooseGroupHandler implements CallbackHandler {
     private static final Logger log = LoggerFactory.getLogger(ChooseGroupHandler.class);
+    private final Action action = Action.chooseGroup;
 
     @Override
     public String getFormat() {
-        return Action.chooseGroup + "_<groupId>";
+        return action + "_<groupId>";
+    }
+
+    @Override
+    public Action getAction() {
+        return action;
     }
 
     @Override

--- a/src/main/java/bot/core/control/callbackHandlers/ChooseTagHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/ChooseTagHandler.java
@@ -22,7 +22,7 @@ public class ChooseTagHandler extends AbstractCallbackHandler {
 
     @Override
     public String getFormat() {
-        return "chooseTag_<tag>";
+        return action + "_<tag>";
     }
 
     @Override

--- a/src/main/java/bot/core/control/callbackHandlers/ConfirmHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/ConfirmHandler.java
@@ -14,10 +14,16 @@ import org.telegram.telegrambots.meta.api.objects.Update;
  */
 public class ConfirmHandler implements CallbackHandler {
     private static final Logger log = LoggerFactory.getLogger(ConfirmHandler.class);
+    private final Action action = Action.confirm;
 
     @Override
     public String getFormat() {
-        return "confirm_<messageId>_<userId>";
+        return action + "_<messageId>_<userId>";
+    }
+
+    @Override
+    public Action getAction() {
+        return action;
     }
 
     @Override

--- a/src/main/java/bot/core/control/callbackHandlers/DeclineHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/DeclineHandler.java
@@ -20,10 +20,16 @@ import java.time.Instant;
 
 public class DeclineHandler implements CallbackHandler {
     private static final Logger log = LoggerFactory.getLogger(DeclineHandler.class);
+    private final Action action = Action.decline;
 
     @Override
     public String getFormat() {
-        return "decline_<messageId>_<userId>";
+        return action + "_<messageId>_<userId>";
+    }
+
+    @Override
+    public Action getAction() {
+        return action;
     }
 
     @Override

--- a/src/main/java/bot/core/control/callbackHandlers/DelGroupHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/DelGroupHandler.java
@@ -7,9 +7,15 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class DelGroupHandler implements CallbackHandler {
+    private final Action action = Action.delGroup;
     @Override
     public String getFormat() {
-        return "delGroup_<groupId>";
+        return action + "_<groupId>";
+    }
+
+    @Override
+    public Action getAction() {
+        return action;
     }
 
     @Override

--- a/src/main/java/bot/core/control/callbackHandlers/GetJoinRequestedLinkHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/GetJoinRequestedLinkHandler.java
@@ -6,6 +6,7 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Update;
 
 public class GetJoinRequestedLinkHandler implements CallbackHandler {
+    private final Action action = Action.getJoinRequestedLink;
     @Override
     public boolean match(Update update) {
         return update.hasCallbackQuery() && update.getCallbackQuery().getData().startsWith(Action.getJoinRequestedLink.toString() + "_");
@@ -31,6 +32,11 @@ public class GetJoinRequestedLinkHandler implements CallbackHandler {
 
     @Override
     public String getFormat() {
-        return "getJoinRequestedLink_<link>_<chatId>";
+        return action + "_<link>_<chatId>";
+    }
+
+    @Override
+    public Action getAction() {
+        return action;
     }
 }

--- a/src/main/java/bot/core/control/callbackHandlers/SetTagHandler.java
+++ b/src/main/java/bot/core/control/callbackHandlers/SetTagHandler.java
@@ -11,9 +11,15 @@ import org.telegram.telegrambots.meta.api.objects.Update;
 import java.util.Map;
 
 public class SetTagHandler implements CallbackHandler {
+    private final Action action = Action.setTag;
     @Override
     public String getFormat() {
-        return "setTag_<tagId>";
+        return action + "_<tagId>";
+    }
+
+    @Override
+    public Action getAction() {
+        return action;
     }
 
     private static final Logger log = LoggerFactory.getLogger(SetTagHandler.class);

--- a/src/main/java/bot/core/control/messageProcessing/CallbackProcessor.java
+++ b/src/main/java/bot/core/control/messageProcessing/CallbackProcessor.java
@@ -9,8 +9,8 @@ import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.EnumMap;
+import java.util.Map;
 
 public class CallbackProcessor implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(CallbackProcessor.class);
@@ -25,34 +25,49 @@ public class CallbackProcessor implements MessageProcessor {
         handleCallbackQuery(update);
     }
 
-    private final List<CallbackHandler> handlers = Arrays.asList(
-            new ConfirmHandler(),
-            new DeclineHandler(),
-            new ChooseGroupHandler(),
-            new SetTagHandler(),
-            new DelGroupHandler(),
-            new GetJoinRequestedLinkHandler(),
-            new ChooseTagHandler(),
-            new GetInstructionHandler(),
-            new ChooseAllCourseHandler(),
-            new GetPaymentInstructionHandler(),
-            new GetCourseDescriptionHandler()
-    );
+    private final Map<Action, CallbackHandler> handlers = new EnumMap<>(Action.class);
+
+    {
+        CallbackHandler[] list = new CallbackHandler[]{
+                new ConfirmHandler(),
+                new DeclineHandler(),
+                new ChooseGroupHandler(),
+                new SetTagHandler(),
+                new DelGroupHandler(),
+                new GetJoinRequestedLinkHandler(),
+                new ChooseTagHandler(),
+                new GetInstructionHandler(),
+                new ChooseAllCourseHandler(),
+                new GetPaymentInstructionHandler(),
+                new GetCourseDescriptionHandler()
+        };
+        for (CallbackHandler handler : list) {
+            handlers.put(handler.getAction(), handler);
+        }
+    }
 
     public void handleCallbackQuery(Update update) {
         CallbackQuery callbackQuery = update.getCallbackQuery();
 
-        for (CallbackHandler handler : handlers) {
-            if (handler.match(update)) {
-                if (!handler.isFormatCorrect(callbackQuery.getData())) {
-                    log.error("!!!Incorrect callback format \nprovided: {} \nrecuaerd: {}",
-                            callbackQuery.getData(),
-                            handler.getFormat());
-                } else {
-                    handler.handle(update);
-                }
-                break;
+        String data = callbackQuery.getData();
+        String actionString = data.split("_", 2)[0];
+        Action action = null;
+        try {
+            action = Action.valueOf(actionString);
+        } catch (IllegalArgumentException e) {
+            log.error("Unknown callback action {}", actionString);
+        }
+        CallbackHandler handler = handlers.get(action);
+        if (handler != null && handler.match(update)) {
+            if (!handler.isFormatCorrect(data)) {
+                log.error("!!!Incorrect callback format \nprovided: {} \nrecuaerd: {}",
+                        data,
+                        handler.getFormat());
+            } else {
+                handler.handle(update);
             }
+        } else {
+            log.error("No handler for action {}", actionString);
         }
 
         try {


### PR DESCRIPTION
## Summary
- require callback handlers to expose the `Action` they handle
- store the action inside each handler implementation
- inherit action retrieval in `AbstractCallbackHandler`
- dispatch callbacks using an `Action` -> handler map

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6863ba0585a0832aa5a9a5cf7c14d759