### PR TITLE
Add QuizBot module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# QuizBot
+
+This project provides a simple Telegram bot that runs a questionnaire based on Ayurvedic dosha principles. All questions are loaded from `data/dosha_test.txt` and sessions are stored only in memory.
+
+## Running
+
+1. Configure your Telegram bot token and name in `DataUtils` or start the bot with your own runner.
+2. Build with Maven `mvn package` (Java 21 is required).
+3. Launch `quizbot.core.QuizBot` providing the token and bot name.
+
+## Tests
+
+Unit and integration tests are located under `src/test/java/quizbot`. They cover file parsing, question flow and basic bot interaction.
+

--- a/data/dosha_test.txt
+++ b/data/dosha_test.txt
@@ -1,0 +1,12 @@
+#BLOCK VATA
+My height is noticeably above or below average.
+My physique is thin with pronounced bones.
+I tend to speak quickly and energetically.
+#BLOCK PITTA
+My height is average and proportions are harmonious.
+I have a strong appetite and dislike skipping meals.
+People say I am decisive and focused.
+#BLOCK KAPHA
+My build is sturdy and I gain weight easily.
+I have a calm and steady personality.
+I prefer routine and comfort.

--- a/src/main/java/quizbot/core/ButtonsFactory.java
+++ b/src/main/java/quizbot/core/ButtonsFactory.java
@@ -1,0 +1,24 @@
+package quizbot.core;
+
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ButtonsFactory {
+    public static InlineKeyboardMarkup answerButtons() {
+        List<List<InlineKeyboardButton>> rows = new ArrayList<>();
+        List<InlineKeyboardButton> row = new ArrayList<>();
+        for (int i = 7; i >= 0; i--) {
+            InlineKeyboardButton b = new InlineKeyboardButton();
+            b.setText(String.valueOf(i));
+            b.setCallbackData("ANSWER_" + i);
+            row.add(b);
+        }
+        rows.add(row);
+        InlineKeyboardMarkup markup = new InlineKeyboardMarkup();
+        markup.setKeyboard(rows);
+        return markup;
+    }
+}

--- a/src/main/java/quizbot/core/QuizBot.java
+++ b/src/main/java/quizbot/core/QuizBot.java
@@ -1,0 +1,138 @@
+package quizbot.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.bots.TelegramLongPollingBot;
+import java.util.ArrayList;
+import java.util.List;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import quizbot.model.AnswerScale;
+import quizbot.model.Session;
+import quizbot.test.DoshaTestLoader;
+import quizbot.test.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class QuizBot extends TelegramLongPollingBot {
+    private static final Logger log = LoggerFactory.getLogger(QuizBot.class);
+    private final SessionManager sessions = new SessionManager();
+    private final String token;
+    private final String name;
+
+    public QuizBot(String token, String name) {
+        super(token);
+        this.token = token;
+        this.name = name;
+    }
+
+    @Override
+    public void onUpdateReceived(Update update) {
+        try {
+            if (update.hasMessage() && update.getMessage().hasText()) {
+                handleMessage(update.getMessage());
+            } else if (update.hasCallbackQuery()) {
+                handleCallback(update.getCallbackQuery());
+            }
+        } catch (Exception e) {
+            log.error("Update handling failed", e);
+        }
+    }
+
+    private void handleMessage(Message message) throws Exception {
+        long userId = message.getFrom().getId();
+        String text = message.getText();
+        if ("/start".equals(text)) {
+            SendMessage sm = SendMessage.builder()
+                    .chatId(String.valueOf(message.getChatId()))
+                    .text("Choose option:")
+                    .replyMarkup(mainMenu())
+                    .build();
+            execute(sm);
+        }
+    }
+
+    private InlineKeyboardMarkup mainMenu() {
+        InlineKeyboardButtonFactory factory = new InlineKeyboardButtonFactory();
+        return factory.mainMenu();
+    }
+
+    private void handleCallback(CallbackQuery cb) throws Exception {
+        long userId = cb.getFrom().getId();
+        String data = cb.getData();
+        if (data.equals("ABOUT")) {
+            SendMessage sm = new SendMessage();
+            sm.setChatId(cb.getMessage().getChatId().toString());
+            sm.setText("Dosha service: https://example.com");
+            execute(sm);
+            return;
+        }
+        if (data.equals("START_TEST")) {
+            startTest(cb);
+            return;
+        }
+        if (data.startsWith("ANSWER_")) {
+            int score = Integer.parseInt(data.substring("ANSWER_".length()));
+            Session session = sessions.get(userId);
+            if (session != null) {
+                session.getTest().registerAnswer(score);
+                sendNextQuestion(session, cb.getMessage().getChatId());
+            }
+            return;
+        }
+    }
+
+    private void startTest(CallbackQuery cb) throws IOException, Exception {
+        long userId = cb.getFrom().getId();
+        Test test = DoshaTestLoader.loadDefault();
+        Session session = new Session(userId, test);
+        sessions.getOrCreate(userId, session);
+        sendNextQuestion(session, cb.getMessage().getChatId());
+    }
+
+    private void sendNextQuestion(Session session, long chatId) throws Exception {
+        Test test = session.getTest();
+        Optional<String> q = test.nextQuestion();
+        if (q.isPresent()) {
+            SendMessage sm = new SendMessage();
+            sm.setChatId(String.valueOf(chatId));
+            sm.setText(q.get());
+            sm.setReplyMarkup(ButtonsFactory.answerButtons());
+            execute(sm);
+        } else if (test.isFinished()) {
+            SendMessage sm = new SendMessage();
+            sm.setChatId(String.valueOf(chatId));
+            sm.setText(test.result().toString());
+            execute(sm);
+            sessions.remove(session.getUserId());
+        }
+    }
+
+    @Override
+    public String getBotUsername() {
+        return name;
+    }
+}
+
+class InlineKeyboardButtonFactory {
+    InlineKeyboardMarkup mainMenu() {
+        List<List<org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton>> rows = new ArrayList<>();
+
+        org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton test = new org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton();
+        test.setText("Take Dosha Test");
+        test.setCallbackData("START_TEST");
+        org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton about = new org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton();
+        about.setText("About");
+        about.setCallbackData("ABOUT");
+
+        rows.add(List.of(test, about));
+        InlineKeyboardMarkup markup = new InlineKeyboardMarkup();
+        markup.setKeyboard(rows);
+        return markup;
+    }
+}

--- a/src/main/java/quizbot/core/SessionManager.java
+++ b/src/main/java/quizbot/core/SessionManager.java
@@ -1,0 +1,46 @@
+package quizbot.core;
+
+import quizbot.model.Session;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SessionManager {
+    private static final long TIMEOUT_MILLIS = 20 * 60 * 1000; // 20 minutes
+
+    private final Map<Long, SessionHolder> sessions = new ConcurrentHashMap<>();
+
+    public Session getOrCreate(long userId, Session session) {
+        sessions.putIfAbsent(userId, new SessionHolder(session));
+        return sessions.get(userId).session;
+    }
+
+    public Session get(long userId) {
+        SessionHolder holder = sessions.get(userId);
+        if (holder == null) return null;
+        holder.touch();
+        return holder.session;
+    }
+
+    public void remove(long userId) {
+        sessions.remove(userId);
+    }
+
+    public void purgeExpired() {
+        long now = Instant.now().toEpochMilli();
+        sessions.entrySet().removeIf(e -> now - e.getValue().lastTouch > TIMEOUT_MILLIS);
+    }
+
+    private static class SessionHolder {
+        final Session session;
+        volatile long lastTouch;
+        SessionHolder(Session session) {
+            this.session = session;
+            touch();
+        }
+        void touch() {
+            lastTouch = Instant.now().toEpochMilli();
+        }
+    }
+}

--- a/src/main/java/quizbot/model/AnswerScale.java
+++ b/src/main/java/quizbot/model/AnswerScale.java
@@ -1,0 +1,31 @@
+package quizbot.model;
+
+public enum AnswerScale {
+    SCORE_0(0),
+    SCORE_1(1),
+    SCORE_2(2),
+    SCORE_3(3),
+    SCORE_4(4),
+    SCORE_5(5),
+    SCORE_6(6),
+    SCORE_7(7);
+
+    private final int value;
+
+    AnswerScale(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static AnswerScale fromValue(int v) {
+        for (AnswerScale a : values()) {
+            if (a.value == v) {
+                return a;
+            }
+        }
+        throw new IllegalArgumentException("Unknown value: " + v);
+    }
+}

--- a/src/main/java/quizbot/model/DoshaResult.java
+++ b/src/main/java/quizbot/model/DoshaResult.java
@@ -1,0 +1,64 @@
+package quizbot.model;
+
+import java.util.Arrays;
+import java.util.Comparator;
+
+public class DoshaResult {
+    private final int vata;
+    private final int pitta;
+    private final int kapha;
+
+    public DoshaResult(int vata, int pitta, int kapha) {
+        this.vata = vata;
+        this.pitta = pitta;
+        this.kapha = kapha;
+    }
+
+    public int getVata() {
+        return vata;
+    }
+
+    public int getPitta() {
+        return pitta;
+    }
+
+    public int getKapha() {
+        return kapha;
+    }
+
+    public String dominant() {
+        int[] scores = {vata, pitta, kapha};
+        int max = Arrays.stream(scores).max().orElse(0);
+        long countMax = Arrays.stream(scores).filter(s -> s == max).count();
+        if (countMax > 1) {
+            return "Mixed"; // unusual but handle gracefully
+        }
+        if (max == vata) return "Vata";
+        if (max == pitta) return "Pitta";
+        return "Kapha";
+    }
+
+    public boolean isDoubleType() {
+        int[] scores = {vata, pitta, kapha};
+        int max = Arrays.stream(scores).max().orElse(0);
+        int second = Arrays.stream(scores)
+                .boxed()
+                .sorted(Comparator.reverseOrder())
+                .skip(1)
+                .findFirst().orElse(0);
+        return max > 0 && Math.abs(max - second) <= max * 0.1;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Vata: ").append(vata).append("\n")
+          .append("Pitta: ").append(pitta).append("\n")
+          .append("Kapha: ").append(kapha).append("\n\n");
+        sb.append("Leading - ").append(dominant()).append('.');
+        if (isDoubleType()) {
+            sb.append(" Mixed type detected.");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/quizbot/model/Session.java
+++ b/src/main/java/quizbot/model/Session.java
@@ -1,0 +1,21 @@
+package quizbot.model;
+
+import quizbot.test.Test;
+
+public class Session {
+    private final long userId;
+    private final Test test;
+
+    public Session(long userId, Test test) {
+        this.userId = userId;
+        this.test = test;
+    }
+
+    public long getUserId() {
+        return userId;
+    }
+
+    public Test getTest() {
+        return test;
+    }
+}

--- a/src/main/java/quizbot/test/DoshaTestLoader.java
+++ b/src/main/java/quizbot/test/DoshaTestLoader.java
@@ -1,0 +1,39 @@
+package quizbot.test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DoshaTestLoader {
+    public static Test load(Path path) throws IOException {
+        List<List<String>> blocks = new ArrayList<>();
+        List<String> current = new ArrayList<>();
+        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty()) continue;
+                if (line.startsWith("#BLOCK")) {
+                    if (!current.isEmpty()) {
+                        blocks.add(new ArrayList<>(current));
+                        current.clear();
+                    }
+                    continue;
+                }
+                current.add(line);
+            }
+        }
+        if (!current.isEmpty()) {
+            blocks.add(current);
+        }
+        return Test.fromBlocks(blocks);
+    }
+
+    public static Test loadDefault() throws IOException {
+        return load(Path.of("data", "dosha_test.txt"));
+    }
+}

--- a/src/main/java/quizbot/test/Test.java
+++ b/src/main/java/quizbot/test/Test.java
@@ -1,0 +1,51 @@
+package quizbot.test;
+
+import quizbot.model.DoshaResult;
+
+import java.util.List;
+import java.util.Optional;
+
+public class Test {
+    private final List<List<String>> blocks;
+    private int currentBlock = 0;
+    private int currentQuestion = 0;
+    private final int[] scores = new int[3];
+
+    public Test(List<List<String>> blocks) {
+        this.blocks = blocks;
+    }
+
+    public Optional<String> nextQuestion() {
+        if (currentBlock >= blocks.size()) {
+            return Optional.empty();
+        }
+        List<String> currentList = blocks.get(currentBlock);
+        if (currentQuestion >= currentList.size()) {
+            currentBlock++;
+            currentQuestion = 0;
+            if (currentBlock >= blocks.size()) {
+                return Optional.empty();
+            }
+            currentList = blocks.get(currentBlock);
+        }
+        return Optional.of(currentList.get(currentQuestion++));
+    }
+
+    public void registerAnswer(int score) {
+        if (currentBlock < scores.length) {
+            scores[currentBlock] += score;
+        }
+    }
+
+    public boolean isFinished() {
+        return currentBlock >= blocks.size();
+    }
+
+    public DoshaResult result() {
+        return new DoshaResult(scores[0], scores[1], scores[2]);
+    }
+
+    public static Test fromBlocks(List<List<String>> blocks) {
+        return new Test(blocks);
+    }
+}

--- a/src/test/java/quizbot/DoshaResultTest.java
+++ b/src/test/java/quizbot/DoshaResultTest.java
@@ -1,0 +1,21 @@
+package quizbot;
+
+import org.junit.Test;
+import quizbot.model.DoshaResult;
+
+import static org.junit.Assert.*;
+
+public class DoshaResultTest {
+    @Test
+    public void testDominant() {
+        DoshaResult r = new DoshaResult(30, 20, 10);
+        assertEquals("Vata", r.dominant());
+        assertFalse(r.isDoubleType());
+    }
+
+    @Test
+    public void testDoubleType() {
+        DoshaResult r = new DoshaResult(30, 28, 5);
+        assertTrue(r.isDoubleType());
+    }
+}

--- a/src/test/java/quizbot/DoshaTestLoaderTest.java
+++ b/src/test/java/quizbot/DoshaTestLoaderTest.java
@@ -1,0 +1,18 @@
+package quizbot;
+
+import org.junit.Test;
+import quizbot.test.DoshaTestLoader;
+import quizbot.test.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+public class DoshaTestLoaderTest {
+    @Test
+    public void testLoad() throws Exception {
+        Test t = DoshaTestLoader.load(Path.of("data", "dosha_test.txt"));
+        assertNotNull(t);
+        assertTrue(t.nextQuestion().isPresent());
+    }
+}

--- a/src/test/java/quizbot/QuizBotIntegrationTest.java
+++ b/src/test/java/quizbot/QuizBotIntegrationTest.java
@@ -1,0 +1,39 @@
+package quizbot;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import quizbot.core.QuizBot;
+import quizbot.core.SessionManager;
+import quizbot.model.Session;
+import quizbot.test.DoshaTestLoader;
+import quizbot.test.Test;
+
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.*;
+
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class QuizBotIntegrationTest {
+    @Test
+    public void testStartCommand() throws Exception {
+        QuizBot bot = spy(new QuizBot("token", "name"));
+        Update upd = new Update();
+        Message m = new Message();
+        m.setText("/start");
+        User u = new User();
+        u.setId(1L);
+        m.setFrom(u);
+        Chat chat = new Chat();
+        chat.setId(1L);
+        chat.setType("private");
+        m.setChat(chat);
+        upd.setMessage(m);
+
+        doNothing().when(bot).execute(any(SendMessage.class));
+        bot.onUpdateReceived(upd);
+        verify(bot, atLeastOnce()).execute(any(SendMessage.class));
+    }
+}

--- a/src/test/java/quizbot/TestFlowTest.java
+++ b/src/test/java/quizbot/TestFlowTest.java
@@ -1,0 +1,23 @@
+package quizbot;
+
+import org.junit.Test;
+import quizbot.test.DoshaTestLoader;
+import quizbot.test.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+public class TestFlowTest {
+    @Test
+    public void testQuestionFlow() throws Exception {
+        Test t = DoshaTestLoader.load(Path.of("data", "dosha_test.txt"));
+        int count = 0;
+        while (t.nextQuestion().isPresent()) {
+            t.registerAnswer(1);
+            count++;
+        }
+        assertTrue(t.isFinished());
+        assertEquals(9, count);
+    }
+}


### PR DESCRIPTION
## Summary
- implement a new QuizBot module under the `quizbot` package
- load questions from `data/dosha_test.txt`
- provide session management and inline button factory
- add unit and integration tests
- document usage in README

## Testing
- `mvn package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e8ce1e70832a9110c79327d25d6e